### PR TITLE
Corrige cálculo de fecha_sintomas y fecha_recuperacion

### DIFF
--- a/app.py
+++ b/app.py
@@ -140,14 +140,14 @@ app.layout = html.Div([
                 ),
                 html.Div([
                     html.P(0, id='num_inf', className='data_value'),
-                    html.P('Infectados activos', className='data_info'),
+                    html.P('Infecciosos estimados', className='data_info'),
                 ],
                     style={'width': '25%'},
                     className='pretty_container',
                 ),
                 html.Div([
                     html.P(0, id='num_rec', className='data_value'),
-                    html.P('Recuperados', className='data_info')
+                    html.P('Recuperados estimados', className='data_info')
                 ],
                     style={'width': '25%'},
                     className='pretty_container',
@@ -442,7 +442,7 @@ def update_figure(start_date: datetime, end_date: datetime, autotiempo: str, tre
         *update_deaths(df_covid_filter, df_covid_raw_filter, daily_deaths, cum_deaths),
         status_infectados,
         round(df['dias'].median(skipna=True), 2),
-        thousand_sep(int(df_covid.loc[current_date, 'infectados'] - df_covid.loc[current_date, 'recuperados'])),
+        thousand_sep(int(df_covid.loc[current_date, 'estimados'] - df_covid.loc[current_date, 'recuperados'])),
         thousand_sep(int(df_covid.loc[current_date, 'recuperados'] - df_covid.loc[current_date, 'fallecidos'])),
         thousand_sep(int(df_covid.loc[current_date, 'fallecidos'])),
         slider_disabled,


### PR DESCRIPTION
Para los asintomáticos asigna fecha_sintomas de la siguiente manera:
- Toma `w :=` la media de retraso en el reporte para el departamento del paciente 
- Calcula `f :=` fecha_reporte - w
- Asigna como fecha_sintomas min(f, fecha_recuperacion, fecha_muerte)

La fecha_recuperacion se asigna de la siguiente manera:
- Para los fallecidos asigna la fecha_recuperacion como fecha_muerte
- Para el resto de pacientes se asume que el tiempo de recuperación es a lo más 13 días (este valor es parametrizable). Así: fecha_recuperacion = min(fecha_sintomas + 13, fecha_recuperacion)